### PR TITLE
Merge Conflict 해결

### DIFF
--- a/src/main/java/com/sparta/twotwo/TwotwoApplication.java
+++ b/src/main/java/com/sparta/twotwo/TwotwoApplication.java
@@ -2,8 +2,10 @@ package com.sparta.twotwo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 public class TwotwoApplication {

--- a/src/main/java/com/sparta/twotwo/TwotwoApplication.java
+++ b/src/main/java/com/sparta/twotwo/TwotwoApplication.java
@@ -2,7 +2,9 @@ package com.sparta.twotwo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class TwotwoApplication {
 

--- a/src/main/java/com/sparta/twotwo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/twotwo/auth/config/SecurityConfig.java
@@ -53,8 +53,14 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.PUT, "/api/products/**").hasAnyRole("OWNER", "MANAGER")
                     .requestMatchers(HttpMethod.DELETE, "/api/products/**").hasAnyRole("OWNER", "MANAGER")
 
-
                     //orders
+                    .requestMatchers(HttpMethod.GET, "/api/stores/**").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/stores").hasAnyRole("MASTER", "MANAGER")
+                    .requestMatchers(HttpMethod.PUT, "/api/stores/**").hasAnyRole("MASTER", "MANAGER")
+                    .requestMatchers(HttpMethod.DELETE, "/api/stores/**").hasAnyRole("MASTER", "MANAGER")
+
+                    //categories
+                    .requestMatchers(HttpMethod.POST, "/api/categories").hasAnyRole("MASTER", "MANAGER")
 
                     //review
                     .requestMatchers(HttpMethod.POST, "/api/reviews").hasAnyRole("MASTER", "MANAGER", "CUSTOMER")

--- a/src/main/java/com/sparta/twotwo/common/config/AsyncConfig.java
+++ b/src/main/java/com/sparta/twotwo/common/config/AsyncConfig.java
@@ -1,0 +1,35 @@
+package com.sparta.twotwo.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements SchedulingConfigurer {
+
+    @Bean
+    public ThreadPoolTaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("StoreUpdate-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+        executor.setPoolSize(10);
+        executor.setThreadNamePrefix("StoreScheduler-");
+        executor.initialize();
+
+        taskRegistrar.setTaskScheduler(executor);
+    }
+}

--- a/src/main/java/com/sparta/twotwo/store/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/twotwo/store/controller/StoreCategoryController.java
@@ -1,0 +1,36 @@
+package com.sparta.twotwo.store.controller;
+
+import com.sparta.twotwo.common.response.ApiResponse;
+import com.sparta.twotwo.store.dto.request.StoreCategoryRequestDto;
+import com.sparta.twotwo.store.dto.request.StoreCreateRequestDto;
+import com.sparta.twotwo.store.dto.response.StoreCategoryResponseDto;
+import com.sparta.twotwo.store.entity.StoreCategory;
+import com.sparta.twotwo.store.service.StoreCategoryService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class StoreCategoryController {
+
+    private final StoreCategoryService storeCategoryService;
+
+    @PostMapping("/categories")
+    public ResponseEntity<ApiResponse<StoreCategoryResponseDto>> saveCategory(
+            @Valid @RequestBody StoreCategoryRequestDto request
+    ) throws Exception {
+
+        StoreCategory storeCategory = storeCategoryService.saveCategory(
+                request.getName()
+        );
+        return ResponseEntity.ok(ApiResponse.success(StoreCategoryResponseDto.from(storeCategory)));
+    }
+
+
+}

--- a/src/main/java/com/sparta/twotwo/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/twotwo/store/controller/StoreController.java
@@ -74,7 +74,16 @@ public class StoreController {
     public ResponseEntity<ApiResponse<StoreDetailResponse>> createStore(
             @Valid @RequestBody StoreCreateRequest request
     ) throws Exception {
-        Store store = storeService.saveStore(request);
+        Store store = storeService.saveStore(
+                request.getName(),
+                request.getMemberId(),
+                request.getAddress(),
+                request.getCategoryId(),
+                request.getImageUrl(),
+                request.getMinOrderPrice(),
+                request.getOperationStartedAt(),
+                request.getOperationClosedAt()
+        );
         return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(store)));
     }
 
@@ -87,7 +96,17 @@ public class StoreController {
             @PathVariable UUID storeId,
             @Valid @RequestBody StoreUpdateRequest request
     ) throws Exception {
-        Store store = storeService.updateStore(storeId,request);
+        Store store = storeService.updateStore(
+                storeId,
+                request.getName(),
+                request.getMemberId(),
+                request.getAddress(),
+                request.getCategoryId(),
+                request.getImageUrl(),
+                request.getMinOrderPrice(),
+                request.getOperationStartedAt(),
+                request.getOperationClosedAt()
+        );
         return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(store)));
     }
 

--- a/src/main/java/com/sparta/twotwo/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/twotwo/store/controller/StoreController.java
@@ -28,6 +28,7 @@ public class StoreController {
 
     /**
      * 가게 전체 조회
+     * 사용자 권한 (Master, Manager, Owner, Customer)
      */
     @GetMapping("/stores")
     public ResponseEntity<ApiResponse<Page<StoreResponse>>> getAllStores(
@@ -40,6 +41,7 @@ public class StoreController {
 
     /**
      * 가게 상세 조회
+     * 사용자 권한 (Master, Manager, Owner, Customer)
      */
     @GetMapping("/stores/{storeId}")
     public ResponseEntity<ApiResponse<StoreDetailResponse>> getStoreDetails(
@@ -52,6 +54,7 @@ public class StoreController {
 
     /**
      * 카테고리별 가게 조회
+     * 사용자 권한 (Master, Manager, Owner, Customer)
      */
     @GetMapping("/categories/{categoryId}/stores")
     public ResponseEntity<ApiResponse<Page<StoreResponse>>> getStoresByCategory(
@@ -65,7 +68,7 @@ public class StoreController {
 
     /**
      * 가게 등록
-     * 사용권한 (
+     * 사용자 권한 (Master, Manager)
      */
     @PostMapping("/stores")
     public ResponseEntity<ApiResponse<StoreDetailResponse>> createStore(
@@ -75,6 +78,10 @@ public class StoreController {
         return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(store)));
     }
 
+    /**
+     * 가게 수정
+     * 사용자 권한 (Master, Manager)
+     */
     @PatchMapping("/stores/{storeId}")
     public ResponseEntity<ApiResponse<StoreDetailResponse>> updateStore(
             @PathVariable UUID storeId,
@@ -84,5 +91,16 @@ public class StoreController {
         return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(store)));
     }
 
+    /**
+     * 가게 삭제
+     * 사용자 권한 (Master, Manager)
+     */
+    @DeleteMapping("/stores/{storeId}")
+    public ResponseEntity<Void> deleteStore(
+            @PathVariable UUID storeId
+    ) throws Exception {
+        storeService.deleteStore(storeId);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/com/sparta/twotwo/store/controller/StoreController.java
+++ b/src/main/java/com/sparta/twotwo/store/controller/StoreController.java
@@ -3,10 +3,10 @@ package com.sparta.twotwo.store.controller;
 import com.sparta.twotwo.common.exception.ErrorCode;
 import com.sparta.twotwo.common.exception.TwotwoApplicationException;
 import com.sparta.twotwo.common.response.ApiResponse;
-import com.sparta.twotwo.store.dto.request.StoreCreateRequest;
-import com.sparta.twotwo.store.dto.request.StoreUpdateRequest;
-import com.sparta.twotwo.store.dto.response.StoreDetailResponse;
-import com.sparta.twotwo.store.dto.response.StoreResponse;
+import com.sparta.twotwo.store.dto.request.StoreCreateRequestDto;
+import com.sparta.twotwo.store.dto.request.StoreUpdateRequestDto;
+import com.sparta.twotwo.store.dto.response.StoreDetailResponseDto;
+import com.sparta.twotwo.store.dto.response.StoreResponseDto;
 import com.sparta.twotwo.store.entity.Store;
 import com.sparta.twotwo.store.service.StoreService;
 import jakarta.validation.Valid;
@@ -31,12 +31,12 @@ public class StoreController {
      * 사용자 권한 (Master, Manager, Owner, Customer)
      */
     @GetMapping("/stores")
-    public ResponseEntity<ApiResponse<Page<StoreResponse>>> getAllStores(
+    public ResponseEntity<ApiResponse<Page<StoreResponseDto>>> getAllStores(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) throws Exception {
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(ApiResponse.success(storeService.getAllStores(pageable).map(StoreResponse::from)));
+        return ResponseEntity.ok(ApiResponse.success(storeService.getAllStores(pageable).map(StoreResponseDto::from)));
     }
 
     /**
@@ -44,10 +44,10 @@ public class StoreController {
      * 사용자 권한 (Master, Manager, Owner, Customer)
      */
     @GetMapping("/stores/{storeId}")
-    public ResponseEntity<ApiResponse<StoreDetailResponse>> getStoreDetails(
+    public ResponseEntity<ApiResponse<StoreDetailResponseDto>> getStoreDetails(
             @PathVariable UUID storeId
     ) {
-        return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(storeService.getStoreDetails(storeId).orElseThrow(
+        return ResponseEntity.ok(ApiResponse.success(StoreDetailResponseDto.from(storeService.getStoreDetails(storeId).orElseThrow(
                 () -> new TwotwoApplicationException(ErrorCode.STORE_BAD_REQUEST)))
         ));
     }
@@ -57,13 +57,13 @@ public class StoreController {
      * 사용자 권한 (Master, Manager, Owner, Customer)
      */
     @GetMapping("/categories/{categoryId}/stores")
-    public ResponseEntity<ApiResponse<Page<StoreResponse>>> getStoresByCategory(
+    public ResponseEntity<ApiResponse<Page<StoreResponseDto>>> getStoresByCategory(
             @PathVariable UUID categoryId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) throws Exception {
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(ApiResponse.success(storeService.getStoresByCategory(categoryId, pageable).map(StoreResponse::from)));
+        return ResponseEntity.ok(ApiResponse.success(storeService.getStoresByCategory(categoryId, pageable).map(StoreResponseDto::from)));
     }
 
     /**
@@ -71,8 +71,8 @@ public class StoreController {
      * 사용자 권한 (Master, Manager)
      */
     @PostMapping("/stores")
-    public ResponseEntity<ApiResponse<StoreDetailResponse>> createStore(
-            @Valid @RequestBody StoreCreateRequest request
+    public ResponseEntity<ApiResponse<StoreDetailResponseDto>> createStore(
+            @Valid @RequestBody StoreCreateRequestDto request
     ) throws Exception {
         Store store = storeService.saveStore(
                 request.getName(),
@@ -84,7 +84,7 @@ public class StoreController {
                 request.getOperationStartedAt(),
                 request.getOperationClosedAt()
         );
-        return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(store)));
+        return ResponseEntity.ok(ApiResponse.success(StoreDetailResponseDto.from(store)));
     }
 
     /**
@@ -92,9 +92,9 @@ public class StoreController {
      * 사용자 권한 (Master, Manager)
      */
     @PatchMapping("/stores/{storeId}")
-    public ResponseEntity<ApiResponse<StoreDetailResponse>> updateStore(
+    public ResponseEntity<ApiResponse<StoreDetailResponseDto>> updateStore(
             @PathVariable UUID storeId,
-            @Valid @RequestBody StoreUpdateRequest request
+            @Valid @RequestBody StoreUpdateRequestDto request
     ) throws Exception {
         Store store = storeService.updateStore(
                 storeId,
@@ -107,7 +107,7 @@ public class StoreController {
                 request.getOperationStartedAt(),
                 request.getOperationClosedAt()
         );
-        return ResponseEntity.ok(ApiResponse.success(StoreDetailResponse.from(store)));
+        return ResponseEntity.ok(ApiResponse.success(StoreDetailResponseDto.from(store)));
     }
 
     /**

--- a/src/main/java/com/sparta/twotwo/store/dto/request/StoreCategoryRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/request/StoreCategoryRequestDto.java
@@ -1,0 +1,11 @@
+package com.sparta.twotwo.store.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public class StoreCategoryRequestDto {
+    private final String name;
+}

--- a/src/main/java/com/sparta/twotwo/store/dto/request/StoreCreateRequest.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/request/StoreCreateRequest.java
@@ -27,7 +27,7 @@ public class StoreCreateRequest {
 
     private final String imageUrl;
 
-    private final Long minOrderPrice = 0L;
+    private final Long minOrderPrice;
 
     @NotNull(message = "운영 시작 시간을 작성해주세요.")
     private final LocalTime operationStartedAt;
@@ -36,12 +36,13 @@ public class StoreCreateRequest {
     private final LocalTime operationClosedAt;
 
     @Builder
-    public StoreCreateRequest(String name, Long memberId, AddressRequest address, UUID categoryId, String imageUrl, LocalTime operationStartedAt, LocalTime operationClosedAt) {
+    public StoreCreateRequest(String name, Long memberId, AddressRequest address, UUID categoryId, String imageUrl, Long minOrderPrice,  LocalTime operationStartedAt, LocalTime operationClosedAt) {
         this.name = name;
         this.memberId = memberId;
         this.address = address;
         this.categoryId = categoryId;
         this.imageUrl = imageUrl;
+        this.minOrderPrice = minOrderPrice;
         this.operationStartedAt = operationStartedAt;
         this.operationClosedAt = operationClosedAt;
     }

--- a/src/main/java/com/sparta/twotwo/store/dto/request/StoreCreateRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/request/StoreCreateRequestDto.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 import java.util.UUID;
 
 @Getter
-public class StoreCreateRequest {
+public class StoreCreateRequestDto {
 
     @NotNull(message = "가게명을 작성해주세요.")
     @Size(max = 50, message = "가게명은 50자를 초과할 수 없습니다.")
@@ -36,7 +36,7 @@ public class StoreCreateRequest {
     private final LocalTime operationClosedAt;
 
     @Builder
-    public StoreCreateRequest(String name, Long memberId, AddressRequest address, UUID categoryId, String imageUrl, Long minOrderPrice,  LocalTime operationStartedAt, LocalTime operationClosedAt) {
+    public StoreCreateRequestDto(String name, Long memberId, AddressRequest address, UUID categoryId, String imageUrl, Long minOrderPrice, LocalTime operationStartedAt, LocalTime operationClosedAt) {
         this.name = name;
         this.memberId = memberId;
         this.address = address;

--- a/src/main/java/com/sparta/twotwo/store/dto/request/StoreUpdateRequestDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/request/StoreUpdateRequestDto.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
-public class StoreUpdateRequest {
+public class StoreUpdateRequestDto {
 
     @Size(max = 50, message = "가게명은 50자를 초과할 수 없습니다.")
     public final String name;

--- a/src/main/java/com/sparta/twotwo/store/dto/response/AddressResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/AddressResponseDto.java
@@ -1,10 +1,6 @@
 package com.sparta.twotwo.store.dto.response;
 
-import com.sparta.twotwo.common.auditing.BaseEntity;
 import com.sparta.twotwo.store.entity.Address;
-import com.sparta.twotwo.store.entity.Area;
-import com.sparta.twotwo.store.entity.Store;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,14 +8,14 @@ import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
-public class AddressResponse {
+public class AddressResponseDto {
 
     private final UUID id;
     private final String roadAddress;
     private final String detailAddress;
 
-    public static AddressResponse from(Address address) {
-        return new AddressResponse(
+    public static AddressResponseDto from(Address address) {
+        return new AddressResponseDto(
                 address.getId(),
                 address.getRoadAddress(),
                 address.getDetailAddress()

--- a/src/main/java/com/sparta/twotwo/store/dto/response/AreaResonseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/AreaResonseDto.java
@@ -1,8 +1,6 @@
 package com.sparta.twotwo.store.dto.response;
 
-import com.sparta.twotwo.store.entity.Address;
 import com.sparta.twotwo.store.entity.Area;
-import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -10,7 +8,7 @@ import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
-public class AreaResonse {
+public class AreaResonseDto {
 
     private final UUID id;
     private final String sido;
@@ -19,8 +17,8 @@ public class AreaResonse {
     private final String admCode;
     private final String zipNum;
 
-    public static AreaResonse from(Area area) {
-        return new AreaResonse(
+    public static AreaResonseDto from(Area area) {
+        return new AreaResonseDto(
                 area.getId(),
                 area.getSido(),
                 area.getSigg(),

--- a/src/main/java/com/sparta/twotwo/store/dto/response/ProductMenuResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/ProductMenuResponseDto.java
@@ -1,6 +1,5 @@
 package com.sparta.twotwo.store.dto.response;
 
-import com.sparta.twotwo.product.dto.ProductResponseDto;
 import com.sparta.twotwo.product.entity.Product;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +8,7 @@ import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
-public class ProductMenuResponse {
+public class ProductMenuResponseDto {
 
     private final UUID id;
     private final String productName;
@@ -19,8 +18,8 @@ public class ProductMenuResponse {
     private final String imageUrl;
     private final boolean isHidden;
 
-    public static ProductMenuResponse from(Product product) {
-        return new ProductMenuResponse(
+    public static ProductMenuResponseDto from(Product product) {
+        return new ProductMenuResponseDto(
                 product.getId(),
                 product.getProductName(),
                 product.getCategoryId(),

--- a/src/main/java/com/sparta/twotwo/store/dto/response/StoreCategoryResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/StoreCategoryResponseDto.java
@@ -1,0 +1,20 @@
+package com.sparta.twotwo.store.dto.response;
+
+import com.sparta.twotwo.store.entity.StoreCategory;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class StoreCategoryResponseDto {
+
+    private final String name;
+
+    public static StoreCategoryResponseDto from(StoreCategory storeCategory) {
+        return new StoreCategoryResponseDto(
+                storeCategory.getName()
+        );
+    }
+
+}
+

--- a/src/main/java/com/sparta/twotwo/store/dto/response/StoreDetailResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/StoreDetailResponseDto.java
@@ -1,12 +1,6 @@
 package com.sparta.twotwo.store.dto.response;
 
-import com.sparta.twotwo.members.entity.Member;
-import com.sparta.twotwo.product.dto.ProductResponseDto;
-import com.sparta.twotwo.product.entity.Product;
-import com.sparta.twotwo.store.entity.Address;
 import com.sparta.twotwo.store.entity.Store;
-import com.sparta.twotwo.store.entity.StoreCategory;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -18,29 +12,29 @@ import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor
-public class StoreDetailResponse {
+public class StoreDetailResponseDto {
 
     private final UUID id;
     private final String name;
     private final String imageUrl;
     private final Long memberId;
-    private final AddressResponse address;
+    private final AddressResponseDto address;
     private final Long minOrderPrice;
-    private final List<ProductMenuResponse> products;
+    private final List<ProductMenuResponseDto> products;
     private final LocalTime operationStartedAt;
     private final LocalTime operationClosedAt;
     private final BigDecimal rating;
     private final Integer reviewCount;
 
-    public static StoreDetailResponse from(Store store) {
-        return new StoreDetailResponse(
+    public static StoreDetailResponseDto from(Store store) {
+        return new StoreDetailResponseDto(
                 store.getId(),
                 store.getName(),
                 store.getImageUrl(),
                 store.getMember().getMember_id(),
-                AddressResponse.from(store.getAddress()),
+                AddressResponseDto.from(store.getAddress()),
                 store.getMinOrderPrice(),
-                store.getProducts().stream().map(ProductMenuResponse::from).collect(Collectors.toList()),
+                store.getProducts().stream().map(ProductMenuResponseDto::from).collect(Collectors.toList()),
                 store.getOperationStartedAt(),
                 store.getOperationClosedAt(),
                 store.getRating(),

--- a/src/main/java/com/sparta/twotwo/store/dto/response/StoreResponseDto.java
+++ b/src/main/java/com/sparta/twotwo/store/dto/response/StoreResponseDto.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
-public class StoreResponse {
+public class StoreResponseDto {
 
     private final UUID id;
     private final String imageUrl;
@@ -19,8 +19,8 @@ public class StoreResponse {
     private final BigDecimal rating;
     private final Integer reviewCount;
 
-    public static StoreResponse from(Store store) {
-        return new StoreResponse(
+    public static StoreResponseDto from(Store store) {
+        return new StoreResponseDto(
                 store.getId(),
                 store.getImageUrl(),
                 store.getName(),

--- a/src/main/java/com/sparta/twotwo/store/entity/Store.java
+++ b/src/main/java/com/sparta/twotwo/store/entity/Store.java
@@ -6,6 +6,7 @@ import com.sparta.twotwo.product.entity.Product;
 import com.sparta.twotwo.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
@@ -59,10 +60,10 @@ public class Store extends BaseEntity {
     private LocalTime operationClosedAt;
 
     @Column(name = "rating", precision = 2, scale = 1)
-    private BigDecimal rating = BigDecimal.valueOf(0.0);
+    private BigDecimal rating;
 
     @Column(name = "review_cnt")
-    private Integer reviewCount = 0;
+    private Integer reviewCount;
 
     @Builder
     public Store(Member member, Address address, String name, Long minOrderPrice, LocalTime operationClosedAt, LocalTime operationStartedAt, StoreCategory category, BigDecimal rating, Integer reviewCount, String imageUrl) {
@@ -93,7 +94,6 @@ public class Store extends BaseEntity {
     public void updateCategory(StoreCategory category) {
         this.category = category;
     }
-
 
     public void updateMinOrderPrice(Long minOrderPrice) {
         this.minOrderPrice = minOrderPrice;

--- a/src/main/java/com/sparta/twotwo/store/entity/Store.java
+++ b/src/main/java/com/sparta/twotwo/store/entity/Store.java
@@ -3,6 +3,7 @@ package com.sparta.twotwo.store.entity;
 import com.sparta.twotwo.common.auditing.BaseEntity;
 import com.sparta.twotwo.members.entity.Member;
 import com.sparta.twotwo.product.entity.Product;
+import com.sparta.twotwo.review.entity.Review;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,9 +14,8 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
-@Setter
 @Entity
-@Table(name="p_store")
+@Table(name = "p_store")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Store extends BaseEntity {
 
@@ -24,41 +24,45 @@ public class Store extends BaseEntity {
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
-    @Column(name="name", unique = true)
+    @Column(name = "name", unique = true)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="member_id", nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne
-    @JoinColumn(name="address_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id", nullable = false)
     private Address address;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="store_category_id", nullable = false)
+    @JoinColumn(name = "store_category_id", nullable = false)
     private StoreCategory category;
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Product> products = new ArrayList<>();
 
-    @Column(name="image_url")
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "store_id")
+    private List<Review> reviews = new ArrayList<>();
+
+    @Column(name = "image_url")
     private String imageUrl;
 
-    @Column(name="min_order_price")
+    @Column(name = "min_order_price")
     private Long minOrderPrice;
 
-    @Column(name="operation_started_at")
+    @Column(name = "operation_started_at")
     private LocalTime operationStartedAt;
 
-    @Column(name="operation_closed_at")
+    @Column(name = "operation_closed_at")
     private LocalTime operationClosedAt;
 
-    @Column(name="rating")
-    private BigDecimal rating;
+    @Column(name = "rating", precision = 2, scale = 1)
+    private BigDecimal rating = BigDecimal.valueOf(0.0);
 
-    @Column(name="review_cnt")
-    private Integer reviewCount;
+    @Column(name = "review_cnt")
+    private Integer reviewCount = 0;
 
     @Builder
     public Store(Member member, Address address, String name, Long minOrderPrice, LocalTime operationClosedAt, LocalTime operationStartedAt, StoreCategory category, BigDecimal rating, Integer reviewCount, String imageUrl) {
@@ -74,5 +78,44 @@ public class Store extends BaseEntity {
         this.reviewCount = reviewCount;
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateMember(Member member) {
+        this.member = member;
+    }
+
+    public void updateAddress(Address address) {
+        this.address = address;
+    }
+
+    public void updateCategory(StoreCategory category) {
+        this.category = category;
+    }
+
+
+    public void updateMinOrderPrice(Long minOrderPrice) {
+        this.minOrderPrice = minOrderPrice;
+    }
+
+    public void updateOperationStartedAt(LocalTime operationStartedAt) {
+        this.operationStartedAt = operationStartedAt;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+    public void updateOperationClosedAt(LocalTime operationClosedAt) {
+        this.operationClosedAt = operationClosedAt;
+    }
+
+    public void updateRating(BigDecimal rating) {
+        this.rating = rating;
+    }
+
+    public void updateReviewCount(Integer reviewCount) {
+        this.reviewCount = reviewCount;
+    }
 
 }

--- a/src/main/java/com/sparta/twotwo/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/twotwo/store/repository/StoreRepository.java
@@ -1,6 +1,5 @@
 package com.sparta.twotwo.store.repository;
 
-import com.sparta.twotwo.store.dto.StoreReviewStats;
 import com.sparta.twotwo.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/sparta/twotwo/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/twotwo/store/repository/StoreRepository.java
@@ -1,11 +1,14 @@
 package com.sparta.twotwo.store.repository;
 
+import com.sparta.twotwo.store.dto.StoreReviewStats;
 import com.sparta.twotwo.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,6 +17,13 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
 
     @Query("SELECT s FROM Store s LEFT JOIN FETCH s.reviews")
     List<Store> findStoresWithReviews();
+
+    @Query("SELECT s.id, COALESCE(AVG(r.rating), 0.0), COUNT(r) FROM Store s LEFT JOIN s.reviews r GROUP BY s.id")
+    List<Object[]> findAverageRatingsAndReviewCount();
+
+    @Modifying
+    @Query("UPDATE Store s SET s.rating = :rating, s.reviewCount = :reviewCount WHERE s.id = :storeId")
+    void updateRatingAndReviewCount(UUID storeId, BigDecimal rating, Integer reviewCount);
 
     Page<Store> findStoresByCategoryId(UUID categoryId, Pageable pageable);
 

--- a/src/main/java/com/sparta/twotwo/store/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/twotwo/store/repository/StoreRepository.java
@@ -4,11 +4,16 @@ import com.sparta.twotwo.store.entity.Store;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
+
+    @Query("SELECT s FROM Store s LEFT JOIN FETCH s.reviews")
+    List<Store> findStoresWithReviews();
 
     Page<Store> findStoresByCategoryId(UUID categoryId, Pageable pageable);
 

--- a/src/main/java/com/sparta/twotwo/store/scheduler/StoreScheduler.java
+++ b/src/main/java/com/sparta/twotwo/store/scheduler/StoreScheduler.java
@@ -34,7 +34,8 @@ public class StoreScheduler {
 
     }
 
-    @Scheduled(fixedRate = 1000000)
+//    @Scheduled(fixedRate = 1000000)
+    @Scheduled(cron = "0 0 * * * *")
     public void updateStoreReviewStats() {
 
         List<Store> stores = storeRepository.findStoresWithReviews();

--- a/src/main/java/com/sparta/twotwo/store/scheduler/StoreScheduler.java
+++ b/src/main/java/com/sparta/twotwo/store/scheduler/StoreScheduler.java
@@ -4,6 +4,7 @@ import com.sparta.twotwo.review.entity.Review;
 import com.sparta.twotwo.store.entity.Store;
 import com.sparta.twotwo.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +20,7 @@ public class StoreScheduler {
     private final StoreRepository storeRepository;
 
     @Transactional
-    @Scheduled(cron = "0 0 * * * *")
+//    @Scheduled(cron = "0 0 * * * *")
     public void updateAverageStoreRatingsAndReviewCountTaskUsingDatabase() {
 
         List<Object[]> reviewStats = storeRepository.findAverageRatingsAndReviewCount();
@@ -33,23 +34,29 @@ public class StoreScheduler {
 
     }
 
-//    @Scheduled(cron = "0 0 * * * *")
-    public void updateAverageStoreRatingsAndReviewCountTaskForMultiThread() {
+    @Scheduled(fixedRate = 1000000)
+    public void updateStoreReviewStats() {
 
         List<Store> stores = storeRepository.findStoresWithReviews();
 
         for (Store store : stores) {
-            List<Review> reviews = store.getReviews();
-            Integer reviewCount = reviews.size();
-
-            double averageRating = reviews.stream().mapToInt(Review::getRating).average().orElse(0.0);
-
-            store.updateRating(BigDecimal.valueOf(averageRating));
-            store.updateReviewCount(reviewCount);
-
-            storeRepository.saveAndFlush(store);
-
+            calculateAndSaveStoreRatingsAsync(store);
         }
+
+    }
+
+    @Async
+    @Transactional
+    public void calculateAndSaveStoreRatingsAsync(Store store) {
+        List<Review> reviews = store.getReviews();
+        Integer reviewCount = reviews.size();
+
+        double averageRating = reviews.stream().mapToInt(Review::getRating).average().orElse(0.0);
+
+        store.updateRating(BigDecimal.valueOf(averageRating));
+        store.updateReviewCount(reviewCount);
+
+        storeRepository.saveAndFlush(store);
     }
 
 }

--- a/src/main/java/com/sparta/twotwo/store/scheduler/StoreScheduler.java
+++ b/src/main/java/com/sparta/twotwo/store/scheduler/StoreScheduler.java
@@ -1,0 +1,42 @@
+package com.sparta.twotwo.store.scheduler;
+
+import com.sparta.twotwo.review.entity.Review;
+import com.sparta.twotwo.review.repository.ReviewRepository;
+import com.sparta.twotwo.store.entity.Store;
+import com.sparta.twotwo.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StoreScheduler {
+
+    private final StoreRepository storeRepository;
+    private final ReviewRepository reviewRepository;
+
+    //    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(fixedRate = 10000000)
+    public void updateAverageStoreRatingsAndReviewCountTask() {
+
+        List<Store> stores = storeRepository.findStoresWithReviews();
+
+        for (Store store : stores) {
+            List<Review> reviews = store.getReviews();
+            Integer reviewCount = reviews.size();
+
+            double averageRating = reviews.stream().mapToInt(Review::getRating).average().orElse(0.0);
+
+            store.updateRating(BigDecimal.valueOf(averageRating));
+            store.updateReviewCount(reviewCount);
+
+            storeRepository.saveAndFlush(store);
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/sparta/twotwo/store/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/twotwo/store/service/StoreCategoryService.java
@@ -1,0 +1,24 @@
+package com.sparta.twotwo.store.service;
+
+import com.sparta.twotwo.store.entity.Store;
+import com.sparta.twotwo.store.entity.StoreCategory;
+import com.sparta.twotwo.store.repository.StoreCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoreCategoryService {
+
+    private final StoreCategoryRepository storeCategoryRepository;
+
+    public StoreCategory saveCategory(String reqName) {
+
+        StoreCategory newStoreCategory = StoreCategory.builder()
+                .name(reqName)
+                .build();
+
+        return storeCategoryRepository.save(newStoreCategory);
+    }
+
+}

--- a/src/main/java/com/sparta/twotwo/store/service/StoreService.java
+++ b/src/main/java/com/sparta/twotwo/store/service/StoreService.java
@@ -4,6 +4,8 @@ import com.sparta.twotwo.common.exception.ErrorCode;
 import com.sparta.twotwo.common.exception.TwotwoApplicationException;
 import com.sparta.twotwo.members.entity.Member;
 import com.sparta.twotwo.members.repository.MemberRepository;
+import com.sparta.twotwo.store.dto.request.AddressRequest;
+import com.sparta.twotwo.store.dto.request.AddressUpdateRequest;
 import com.sparta.twotwo.store.dto.request.StoreCreateRequest;
 import com.sparta.twotwo.store.dto.request.StoreUpdateRequest;
 import com.sparta.twotwo.store.entity.Address;
@@ -18,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -49,21 +52,30 @@ public class StoreService {
     }
 
     @Transactional
-    public Store saveStore(final StoreCreateRequest request) {
+    public Store saveStore(
+            String reqName,
+            Long reqMemberId,
+            AddressRequest reqAddress,
+            UUID reqCategoryId,
+            String reqImageUrl,
+            Long reqMinOrderPrice,
+            LocalTime reqOperationStartedAt,
+            LocalTime reqOperationClosedAt
+    ) {
 
-        Member member = getMemberOrException(request.getMemberId());
-        final Address address = addressService.saveAddress(request.getAddress());
-        StoreCategory category = getCategoryOrException(request.getCategoryId());
-        validateStoreName(request.getName());
+        Member member = getMemberOrException(reqMemberId);
+        final Address address = addressService.saveAddress(reqAddress);
+        StoreCategory category = getCategoryOrException(reqCategoryId);
+        validateStoreName(reqName);
 
         Store newStore = Store.builder()
-                .name(request.getName())
+                .name(reqName)
                 .address(address)
-                .minOrderPrice(request.getMinOrderPrice())
-                .operationClosedAt(request.getOperationClosedAt())
-                .operationStartedAt(request.getOperationStartedAt())
+                .minOrderPrice(reqMinOrderPrice)
+                .operationClosedAt(reqOperationClosedAt)
+                .operationStartedAt(reqOperationStartedAt)
                 .category(category)
-                .imageUrl(request.getImageUrl())
+                .imageUrl(reqImageUrl)
                 .member(member)
                 .build();
 
@@ -75,36 +87,47 @@ public class StoreService {
     }
 
     @Transactional
-    public Store updateStore(UUID storeId, StoreUpdateRequest request) {
+    public Store updateStore(
+            UUID storeId,
+            String reqName,
+            Long reqMemberId,
+            AddressUpdateRequest reqAddress,
+            UUID reqCategoryId,
+            String reqImageUrl,
+            Long reqMinOrderPrice,
+            LocalTime reqOperationStartedAt,
+            LocalTime reqOperationClosedAt
+    ) {
 
         //가게 존재하는지 확인
         Store store = getStoreOrException(storeId);
 
-        validateStoreName(request.getName());
+        validateStoreName(reqName);
 
-        Optional.ofNullable(request.getCategoryId()).ifPresent(categoryId -> {
+        Optional.ofNullable(reqCategoryId).ifPresent(categoryId -> {
                     StoreCategory category = getCategoryOrException(categoryId);
                     store.updateCategory(category);
                 }
         );
 
         //가게 주인 변경
-        Optional.ofNullable(request.getAddress()).ifPresent(requestAddress -> {
+        Optional.ofNullable(reqAddress).ifPresent(requestAddress -> {
                     Address updatedAddress = addressService.updateAddress(requestAddress);
                     store.updateAddress(updatedAddress);
                 }
         );
 
-        Optional.ofNullable(request.getMemberId()).ifPresent(memberId-> {
+        Optional.ofNullable(reqMemberId).ifPresent(memberId -> {
             Member owner = getMemberOrException(memberId);
             store.updateMember(owner);
         });
 
-        Optional.ofNullable(request.getName()).ifPresent(store::updateName);
-        Optional.ofNullable(request.getMinOrderPrice()).ifPresent(store::updateMinOrderPrice);
-        Optional.ofNullable(request.getOperationStartedAt()).ifPresent(store::updateOperationStartedAt);
-        Optional.ofNullable(request.getOperationClosedAt()).ifPresent(store::updateOperationClosedAt);
-        Optional.ofNullable(request.getImageUrl()).ifPresent(store::updateImageUrl);
+        Optional.ofNullable(reqName).ifPresent(store::updateName);
+        Optional.ofNullable(reqImageUrl).ifPresent(store::updateImageUrl);
+        Optional.ofNullable(reqMinOrderPrice).ifPresent(store::updateMinOrderPrice);
+        Optional.ofNullable(reqOperationStartedAt).ifPresent(store::updateOperationStartedAt);
+        Optional.ofNullable(reqOperationClosedAt).ifPresent(store::updateOperationClosedAt);
+
 
         //변경하는 사용자 id 가져오기
         Long modifierId = getMemberIdFromSecurityContext();

--- a/src/main/java/com/sparta/twotwo/store/service/StoreService.java
+++ b/src/main/java/com/sparta/twotwo/store/service/StoreService.java
@@ -77,9 +77,6 @@ public class StoreService {
     @Transactional
     public Store updateStore(UUID storeId, StoreUpdateRequest request) {
 
-        //멤버 가져오기
-        Member member = getMemberOrException(request.getMemberId());
-
         //가게 존재하는지 확인
         Store store = getStoreOrException(storeId);
 
@@ -87,21 +84,27 @@ public class StoreService {
 
         Optional.ofNullable(request.getCategoryId()).ifPresent(categoryId -> {
                     StoreCategory category = getCategoryOrException(categoryId);
-                    store.setCategory(category);
+                    store.updateCategory(category);
                 }
         );
 
+        //가게 주인 변경
         Optional.ofNullable(request.getAddress()).ifPresent(requestAddress -> {
                     Address updatedAddress = addressService.updateAddress(requestAddress);
-                    store.setAddress(updatedAddress);
+                    store.updateAddress(updatedAddress);
                 }
         );
 
-        Optional.ofNullable(request.getName()).ifPresent(store::setName);
-        Optional.ofNullable(request.getMinOrderPrice()).ifPresent(store::setMinOrderPrice);
-        Optional.ofNullable(request.getOperationStartedAt()).ifPresent(store::setOperationStartedAt);
-        Optional.ofNullable(request.getOperationClosedAt()).ifPresent(store::setOperationClosedAt);
-        Optional.ofNullable(request.getImageUrl()).ifPresent(store::setImageUrl);
+        Optional.ofNullable(request.getMemberId()).ifPresent(memberId-> {
+            Member owner = getMemberOrException(memberId);
+            store.updateMember(owner);
+        });
+
+        Optional.ofNullable(request.getName()).ifPresent(store::updateName);
+        Optional.ofNullable(request.getMinOrderPrice()).ifPresent(store::updateMinOrderPrice);
+        Optional.ofNullable(request.getOperationStartedAt()).ifPresent(store::updateOperationStartedAt);
+        Optional.ofNullable(request.getOperationClosedAt()).ifPresent(store::updateOperationClosedAt);
+        Optional.ofNullable(request.getImageUrl()).ifPresent(store::updateImageUrl);
 
         //변경하는 사용자 id 가져오기
         Long modifierId = getMemberIdFromSecurityContext();
@@ -123,7 +126,6 @@ public class StoreService {
 
         return storeRepository.saveAndFlush(store);
     }
-
 
     private void validateStoreName(String storeName) {
         storeRepository.findByName(storeName).ifPresent(it -> {

--- a/src/main/java/com/sparta/twotwo/store/service/StoreService.java
+++ b/src/main/java/com/sparta/twotwo/store/service/StoreService.java
@@ -6,8 +6,6 @@ import com.sparta.twotwo.members.entity.Member;
 import com.sparta.twotwo.members.repository.MemberRepository;
 import com.sparta.twotwo.store.dto.request.AddressRequest;
 import com.sparta.twotwo.store.dto.request.AddressUpdateRequest;
-import com.sparta.twotwo.store.dto.request.StoreCreateRequest;
-import com.sparta.twotwo.store.dto.request.StoreUpdateRequest;
 import com.sparta.twotwo.store.entity.Address;
 import com.sparta.twotwo.store.entity.Store;
 import com.sparta.twotwo.store.entity.StoreCategory;

--- a/src/test/java/com/sparta/twotwo/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/twotwo/store/service/StoreServiceTest.java
@@ -4,7 +4,7 @@ import com.sparta.twotwo.common.exception.TwotwoApplicationException;
 import com.sparta.twotwo.members.entity.Member;
 import com.sparta.twotwo.members.repository.MemberRepository;
 import com.sparta.twotwo.store.dto.request.AddressRequest;
-import com.sparta.twotwo.store.dto.request.StoreCreateRequest;
+import com.sparta.twotwo.store.dto.request.StoreCreateRequestDto;
 import com.sparta.twotwo.store.entity.Address;
 import com.sparta.twotwo.store.entity.Store;
 import com.sparta.twotwo.store.entity.StoreCategory;
@@ -167,7 +167,7 @@ public class StoreServiceTest {
                 .build();
 
 
-        StoreCreateRequest request = StoreCreateRequest.builder()
+        StoreCreateRequestDto request = StoreCreateRequestDto.builder()
                 .name(duplicatedName)
                 .memberId(member.getMember_id())
                 .address(new AddressRequest("sido", "sigg", "emd", "admCode", "zipNum","roadAddress","detailAddress"))

--- a/src/test/java/com/sparta/twotwo/store/service/StoreServiceTest.java
+++ b/src/test/java/com/sparta/twotwo/store/service/StoreServiceTest.java
@@ -27,6 +27,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -169,7 +170,12 @@ public class StoreServiceTest {
         StoreCreateRequest request = StoreCreateRequest.builder()
                 .name(duplicatedName)
                 .memberId(member.getMember_id())
-                .address(addressRequest)
+                .address(new AddressRequest("sido", "sigg", "emd", "admCode", "zipNum","roadAddress","detailAddress"))
+                .categoryId(UUID.randomUUID())
+                .imageUrl("imageUrl")
+                .minOrderPrice(0L)
+                .operationStartedAt(LocalTime.now())
+                .operationClosedAt(LocalTime.now())
                 .build();
 
         StoreCategory category = StoreCategory.builder().name("카테고리 A").build();
@@ -182,7 +188,15 @@ public class StoreServiceTest {
 
         //then
         assertThrows(TwotwoApplicationException.class, () -> {
-            storeService.saveStore(request);
+            storeService.saveStore(
+                    request.getName(),
+                    request.getMemberId(),
+                    request.getAddress(),
+                    request.getCategoryId(),
+                    request.getImageUrl(),
+                    request.getMinOrderPrice(),
+                    request.getOperationStartedAt(),
+                    request.getOperationClosedAt());
         });
     }
 


### PR DESCRIPTION
- 리뷰 평점 평균, 리뷰 수 업데이트하는 스케쥴러 추가
- 스케쥴러는 매일 자정에 실행되게 설정
- 불필요한 쿼리가 발생하지 않게 DB로 평균과 리뷰 수를 찾아서 저장하는 메서드 추가
- 멀티 스레드로 처리할 경우 DB가 비효율적일 것 같아서 추가로 메서드 추가
- 가게 카테고리 등록 API 추가
- Merge 충돌 해결